### PR TITLE
enum_set

### DIFF
--- a/core/include/upp/enum_set.hpp
+++ b/core/include/upp/enum_set.hpp
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <upp/bitset.hpp>
+#include <upp/cast.hpp>
+#include <upp/concepts.hpp>
+#include <upp/enum.hpp>
+
+namespace upp {
+
+/**
+ * \brief Set type for enumerators
+ *
+ * Efficient type for storing enumerations in a set. This is meant for
+ * enumerations that are not "bitmask like", for those types one should
+ * use \a upp::bitmask instead.
+ * */
+template <enum_type E>
+class enum_set {
+ public:
+    constexpr enum_set() noexcept = default;
+    constexpr explicit enum_set(std::initializer_list<E> il) noexcept {
+        for (auto e : il) { *this |= e; }
+    }
+
+    constexpr explicit operator bool() const noexcept { return m_set.any(); }
+
+    constexpr auto& operator|=(E v) noexcept {
+        m_set[*enum_index(v)] = true;
+        return *this;
+    }
+
+    constexpr auto operator|(E v) const noexcept {
+        auto new_set = *this;
+        new_set |= v;
+        return new_set;
+    }
+
+    constexpr bool contains(E v) const noexcept {
+        return m_set[*enum_index(v)];
+    }
+
+ private:
+    bitset<enum_count<E>()> m_set{};
+};
+}  // namespace upp

--- a/core/test/enum_set.cpp
+++ b/core/test/enum_set.cpp
@@ -1,0 +1,27 @@
+#include <gtest/gtest.h>
+
+#include <upp/enum_set.hpp>
+
+enum class sample {
+    a,
+    b,
+    c,
+    d,
+    e,
+};
+
+TEST(Ctor, Default) {
+    auto s = upp::enum_set<sample>();
+    ASSERT_FALSE(s);
+}
+
+TEST(Ctor, Values) {
+    using enum sample;
+    auto s = upp::enum_set<sample>{a, b, c};
+    ASSERT_TRUE(s);
+    ASSERT_TRUE(s.contains(a));
+    ASSERT_TRUE(s.contains(b));
+    ASSERT_TRUE(s.contains(c));
+    ASSERT_FALSE(s.contains(d));
+    ASSERT_FALSE(s.contains(e));
+}

--- a/core/test/meson.build
+++ b/core/test/meson.build
@@ -1,4 +1,4 @@
-tests = files('bitmask.cpp', 'guard.cpp', 'cleanup.cpp', 'flexible.cpp', 'ring_buffer.cpp', 'visit.cpp', 'strlit.cpp', 'enum_array.cpp', 'maybe.cpp', 'bitset.cpp')
+tests = files('bitmask.cpp', 'guard.cpp', 'cleanup.cpp', 'flexible.cpp', 'ring_buffer.cpp', 'visit.cpp', 'strlit.cpp', 'enum_array.cpp', 'maybe.cpp', 'bitset.cpp', 'enum_set.cpp')
 
 # Work in progress
 #tests += files('queue.cpp')


### PR DESCRIPTION
Provides an alternative to upp::bitmask when the targeted enum is not a bitmask and instead stores generic enum values.