### PR TITLE
remove explicit constructor

### DIFF
--- a/core/include/upp/template_str.hpp
+++ b/core/include/upp/template_str.hpp
@@ -13,7 +13,7 @@ template <std::size_t N>
 struct template_str {
     std::array<char, N> data{};
 
-    consteval explicit template_str(const char (&s)[N] /*NOLINT*/) {
+    consteval template_str(const char (&s)[N] /*NOLINT*/) {
         std::copy(s, s + N, data.begin());
     }
 


### PR DESCRIPTION
template_str is meant to be used as non-type template argument where passing a plain string literal is favourable.